### PR TITLE
Fix post path helper and notification badge size

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,7 +7,7 @@
         🔔
         <% unread_count = current_user.notifications.unread.count %>
         <% if unread_count.positive? %>
-          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"><%= unread_count %></span>
+          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="transform: scale(0.5); transform-origin: top right;"><%= unread_count %></span>
         <% end %>
       <% end %></li>
       <li class="nav-item"><%= link_to '/profile', class: "nav-link" do %>👤<% end %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   get("/posts/:post_id/likes", { :controller => "posts", :action => "likes", :as => "post_likes" })
   get("/posts/:post_id/comments", { :controller => "posts", :action => "comments", :as => "post_comments" })
 
-  get("/posts/:path_id", { :controller => "posts", :action => "show" })
+  get("/posts/:path_id", { :controller => "posts", :action => "show", :as => "post" })
 
   # UPDATE
 


### PR DESCRIPTION
## Summary
- name the post show route so `post_path` works in notifications view
- shrink the unread notification badge

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.2.1)*