### PR TITLE
Replace Font Awesome with Bootstrap Icons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ gem "table_print"
 gem "simple_form"
 gem "carrierwave"
 gem "openai-chat"
-gem "font-awesome-sass"
 
 group :development do
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,8 +170,6 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    font-awesome-sass (6.7.2)
-      sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     grade_runner (0.0.13)
@@ -489,7 +487,6 @@ DEPENDENCIES
   draft_matchers
   factory_bot_rails
   faker
-  font-awesome-sass
   grade_runner (~> 0.0.13)
   htmlbeautifier
   http

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -14,9 +14,6 @@
 *= require_self
 */
 
-@import "font-awesome-sprockets";
-@import "font-awesome";
-
 :root {
   --teal: #008080;
   --charcoal: #36454F;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </head>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -21,9 +21,9 @@
   </div>
 
   <div class="post-icons mb-2">
-    <i class="fas fa-image" data-action="post-form#attachMedia"></i>
-    <i class="fas fa-video" data-action="post-form#attachVideo"></i>
-    <i class="fas fa-chart-bar" data-action="post-form#togglePoll"></i>
+    <i class="bi bi-image" data-action="post-form#attachMedia"></i>
+    <i class="bi bi-camera-video" data-action="post-form#attachVideo"></i>
+    <i class="bi bi-bar-chart" data-action="post-form#togglePoll"></i>
   </div>
 
   <%= f.file_field :media, multiple: true, direct_upload: true, class: "d-none", data: {post_form_target: "mediaInput"} %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -3,20 +3,20 @@
     <div class="d-flex align-items-center position-absolute start-0">
       <%= link_to 'N', root_path, class: 'navbar-brand me-3' %>
       <%= link_to '#', class: 'navbar-brand' do %>
-        <i class="fas fa-search"></i>
+        <i class="bi bi-search"></i>
       <% end %>
     </div>
     <ul class="navbar-nav mb-2 mb-lg-0 d-flex flex-row mx-auto justify-content-center">
-      <li class="nav-item me-3"><%= link_to root_path, class: "nav-link #{current_page?(root_path) ? 'active' : ''}" do %><i class="fas fa-home"></i><% end %></li>
-      <li class="nav-item me-3"><%= link_to '/library', class: "nav-link #{request.path == '/library' ? 'active' : ''}" do %><i class="fas fa-book-open"></i><% end %></li>
+      <li class="nav-item me-3"><%= link_to root_path, class: "nav-link #{current_page?(root_path) ? 'active' : ''}" do %><i class="bi bi-house"></i><% end %></li>
+      <li class="nav-item me-3"><%= link_to '/library', class: "nav-link #{request.path == '/library' ? 'active' : ''}" do %><i class="bi bi-book"></i><% end %></li>
       <li class="nav-item me-3"><%= link_to '/notifications', class: "nav-link position-relative #{request.path == '/notifications' ? 'active' : ''}" do %>
-        <i class="fas fa-bell"></i>
+        <i class="bi bi-bell"></i>
         <% unread_count = current_user.notifications.unread.count %>
         <% if unread_count.positive? %>
           <span class="notification-dot"></span>
         <% end %>
       <% end %></li>
-      <li class="nav-item"><%= link_to '/profile', class: "nav-link #{request.path == '/profile' ? 'active' : ''}" do %><i class="fas fa-user"></i><% end %></li>
+      <li class="nav-item"><%= link_to '/profile', class: "nav-link #{request.path == '/profile' ? 'active' : ''}" do %><i class="bi bi-person"></i><% end %></li>
     </ul>
     <span class="navbar-text position-absolute end-0"><%= @page_title %></span>
   </div>


### PR DESCRIPTION
## Summary
- remove Font Awesome gem and styles
- include Bootstrap Icons via CDN
- update navbar and posts page to use Bootstrap icon classes

## Testing
- `bin/rails test` *(fails: rbenv: version `ruby-3.2.1` is not installed)*
- `bundle exec rspec` *(fails: rbenv: version `ruby-3.2.1` is not installed)*