### PR TITLE
Fix sign out method and lighten text color

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -18,7 +18,7 @@
   --cb-1: #2c3e50;
   --cb-2: #34495e;
   --cb-3: #3c566e;
-  --light-grey: #F5F5F5;
+  --light-grey: #FFFFF0;
   --charcoal: #36454F;
 }
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,8 +265,8 @@ Devise.setup do |config|
   # The "*/*" below is required to match Internet Explorer requests.
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
-  # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+# The default HTTP method used to sign out a resource. Default is :delete.
+config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
## Summary
- adjust sign-out route to use DELETE as expected
- update default text color variable to ivory

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`