### PR TITLE
Adjust text colors and restore follow actions

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -53,6 +53,12 @@ body {
   border-radius: 4px;
 }
 
+/* Inputs should use dark text since they have light backgrounds */
+.form-control,
+.form-select {
+  color: var(--charcoal);
+}
+
 /* Ensure all text appears in white across the application */
 body,
 h1,

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -5,32 +5,32 @@
 
   <div class="mb-3">
     <%= f.label :name, class: 'text-white' %>
-    <%= f.text_field :name, value: resource.name, autofocus: true, class: "form-control text-white" %>
+    <%= f.text_field :name, value: resource.name, autofocus: true, class: "form-control" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :username, class: 'text-white' %>
-    <%= f.text_field :username, value: resource.username, class: "form-control text-white" %>
+    <%= f.text_field :username, value: resource.username, class: "form-control" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :email, class: 'text-white' %>
-    <%= f.email_field :email, value: resource.email, class: "form-control text-white", autocomplete: "email" %>
+    <%= f.email_field :email, value: resource.email, class: "form-control", autocomplete: "email" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :avatar, "Profile picture URL", class: 'text-white' %>
-    <%= f.text_field :avatar, value: resource.avatar, class: "form-control text-white" %>
+    <%= f.text_field :avatar, value: resource.avatar, class: "form-control" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :banner, "Banner quote", class: 'text-white' %>
-    <%= f.text_field :banner, value: resource.banner, class: "form-control text-white" %>
+    <%= f.text_field :banner, value: resource.banner, class: "form-control" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :bio, class: 'text-white' %>
-    <%= f.text_area :bio, value: resource.bio, class: "form-control text-white" %>
+    <%= f.text_area :bio, value: resource.bio, class: "form-control" %>
   </div>
 
   <div class="mb-3">
@@ -42,12 +42,12 @@
   <p class="text-white">Leave password fields blank if you don't want to change it</p>
   <div class="mb-3">
     <%= f.label :password, class: 'text-white' %>
-    <%= f.password_field :password, autocomplete: "new-password", class: "form-control text-white" %>
+    <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
   </div>
 
   <div class="mb-3">
     <%= f.label :password_confirmation, class: 'text-white' %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control text-white" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
   </div>
 
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,16 @@
         <span><%= link_to "<strong>#{@user.following.count}</strong> Following".html_safe, following_user_path(@user), class: 'text-white' %></span>
       </div>
     </div>
-    <!-- Follow buttons removed: users can no longer send follow requests -->
+    <% unless @user == current_user %>
+      <% fr = current_user.sentfollowrequests.find_by(recipient: @user) %>
+      <% if current_user.following.include?(@user) %>
+        <%= button_to 'Unfollow', unfollow_user_path(@user), method: :delete, class: 'btn btn-secondary btn-sm mt-2' %>
+      <% elsif fr&.status == 'pending' %>
+        <span class="badge bg-secondary mt-2">Request Sent</span>
+      <% else %>
+        <%= button_to 'Follow', follow_user_path(@user), method: :post, class: 'btn btn-primary btn-sm mt-2' %>
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,10 +67,13 @@ Rails.application.routes.draw do
   post("/followrequests/:id/accept", { :controller => "followrequests", :action => "accept", :as => "accept_followrequest" })
   post("/followrequests/:id/decline", { :controller => "followrequests", :action => "decline", :as => "decline_followrequest" })
 
+  post "/users/:id/follow", to: "followrequests#follow", as: :follow_user
+  delete "/users/:id/follow", to: "followrequests#unfollow", as: :unfollow_user
+
   post "/readings/:id", to: "readings#update", as: :update_reading
 
   # READ
-  get("/followrequests", { :controller => "followrequests", :action => "index" })
+  # get("/followrequests", { :controller => "followrequests", :action => "index" })
 
 
   # UPDATE


### PR DESCRIPTION
## Summary
- keep input text dark for white form fields
- allow users to follow or unfollow others again
- auto create follow requests only if recipient is private
- remove white text from edit profile forms

## Testing
- `bundle exec rspec` *(fails: ruby-3.2.1 not installed)*