### PR TITLE
Add feature spec for creating books

### DIFF
--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :author do
+    name { Faker::Book.author }
+    bio { Faker::Lorem.sentence }
+    dob { "1970-01-01" }
+  end
+end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :book do
+    title { Faker::Book.title }
+    image_url { "http://example.com/book.jpg" }
+    association :author
+    description { Faker::Lorem.paragraph }
+    page_length { rand(100..500) }
+    year { rand(1900..2023) }
+    genre { Faker::Book.genre }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password" }
+  end
+end

--- a/spec/features/book_library_spec.rb
+++ b/spec/features/book_library_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Book management', type: :feature do
+  let(:user) { create(:user) }
+  let(:author) { create(:author) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  it 'allows a user to create a book and see it in their library' do
+    visit '/books'
+
+    fill_in 'Title', with: 'My Awesome Book'
+    fill_in 'Image url', with: 'http://example.com/test.jpg'
+    fill_in 'Author', with: author.id
+    fill_in 'Description', with: 'A great read'
+    fill_in 'Page length', with: 150
+    fill_in 'Year', with: 2021
+    fill_in 'Genre', with: 'Fiction'
+
+    click_button 'Create book'
+
+    expect(page).to have_content('Book created successfully')
+
+    visit '/library'
+    expect(page).to have_content('My Awesome Book')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require "capybara/rspec"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 require "support/headless_chrome"
+# Load additional support files
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -39,6 +41,7 @@ RSpec.configure do |config|
   
   # Shoulda matchers for association accessor specs
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+  config.include FactoryBot::Syntax::Methods
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,6 @@
+require 'devise'
+
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers
+  config.after(type: :feature) { Warden.test_reset! }
+end


### PR DESCRIPTION
## Summary
- create factories for users, authors, and books
- add feature spec for adding a book and seeing it in the user's library
- include Devise helpers and FactoryBot in `rails_helper`

## Testing
- `bundle install` *(fails: could not fetch specs)*
- `bundle exec rspec spec/features/book_library_spec.rb` *(fails: rspec not installed)*