### PR TITLE
Add initializer for Open Library API keys

### DIFF
--- a/config/initializers/open_library.rb
+++ b/config/initializers/open_library.rb
@@ -1,0 +1,14 @@
+# Load Open Library API keys from environment variables
+BOOK_SEARCH_KEY = ENV["book_search_key"]
+WORKS_KEY       = ENV["works_key"]
+COVERS_KEY      = ENV["covers_key"]
+
+if Rails.env.development? || Rails.env.test?
+  missing = []
+  missing << "book_search_key" if BOOK_SEARCH_KEY.blank?
+  missing << "works_key"       if WORKS_KEY.blank?
+  missing << "covers_key"      if COVERS_KEY.blank?
+  if missing.any?
+    raise "Missing Open Library environment variable(s): #{missing.join(', ')}"
+  end
+end


### PR DESCRIPTION
## Summary
- create `config/initializers/open_library.rb`
- check for required Open Library env vars and raise in dev/test when missing

## Testing
- `bundle exec rspec` *(fails: `rbenv: version `ruby-3.2.1' is not installed`)*