### PR TITLE
Add book suggestions endpoint and Stimulus controller

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -25,6 +25,18 @@ class BooksController < ApplicationController
     render({ :template => "books/external_search" })
   end
 
+  def suggest
+    results = OpenLibraryClient.search_books(params[:q])
+    suggestions = Array(results["docs"]).first(5).map do |doc|
+      {
+        title: doc["title"],
+        author_name: doc["author_name"],
+        cover_i: doc["cover_i"]
+      }
+    end
+    render json: suggestions
+  end
+
   def show
     the_id = params.fetch("path_id")
 

--- a/app/javascript/controllers/book_suggest_controller.js
+++ b/app/javascript/controllers/book_suggest_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "list"]
+
+  search() {
+    const query = this.inputTarget.value.trim()
+    if (query === "") {
+      this.listTarget.innerHTML = ""
+      return
+    }
+
+    fetch(`/books/suggest?q=${encodeURIComponent(query)}`)
+      .then(response => response.json())
+      .then(data => {
+        this.listTarget.innerHTML = data
+          .map(book => `<option value="${book.title}"></option>`)
+          .join("")
+      })
+  }
+}

--- a/app/views/books/external_search.html.erb
+++ b/app/views/books/external_search.html.erb
@@ -2,7 +2,8 @@
 
 <%= form_with url: '/books/external_search', method: :get, local: true, class: 'mb-4' do %>
   <div class="input-group">
-    <%= text_field_tag :q, params[:q], class: 'form-control', placeholder: 'Search books by title or author' %>
+    <%= text_field_tag :q, params[:q], class: 'form-control', placeholder: 'Search books by title or author', list: 'book-suggestions', data: { controller: 'book-suggest', action: 'input->book-suggest#search', 'book-suggest-target': 'input' } %>
+    <datalist id="book-suggestions" data-book-suggest-target="list"></datalist>
     <button class="btn btn-primary">Search</button>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
   get("/books/search", { :controller => "books", :action => "search" })
 
   get '/books/external_search' => 'books#external_search'
+  get '/books/suggest' => 'books#suggest'
   post '/books/import' => 'books#import'
 
   get("/books/:path_id", { :controller => "books", :action => "show" })

--- a/spec/features/book_suggest_spec.rb
+++ b/spec/features/book_suggest_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Book suggestions", type: :feature, js: true do
+  let(:user) { create(:user) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  it "displays suggestions while typing" do
+    stub_request(:get, "http://www.example.com/books/suggest")
+      .with(query: hash_including(q: "Har"))
+      .to_return(status: 200, body: [{ title: "Harry Potter" }].to_json,
+                 headers: { "Content-Type" => "application/json" })
+
+    visit "/books/external_search"
+
+    fill_in "q", with: "Har"
+
+    expect(page).to have_selector("datalist option[value='Harry Potter']")
+  end
+end


### PR DESCRIPTION
## Summary
- add new route `/books/suggest`
- implement `BooksController#suggest` returning JSON suggestions
- create Stimulus controller to fetch suggestions
- connect suggestions to external search view
- test UI suggestions with feature spec

## Testing
- `bundle exec rspec spec/features/book_suggest_spec.rb` *(fails: rbenv: version `ruby-3.2.1` is not installed)*