### PR TITLE
Add unified search page

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -8,21 +8,11 @@ class BooksController < ApplicationController
   end
 
   def search
-    @page_title = "Search Books"
-
-    if params[:q].present?
-      term = "%#{params[:q]}%"
-      @books = Book.joins(:author).where("books.title ILIKE ? OR authors.name ILIKE ?", term, term)
-    else
-      @books = []
-    end
-
-    render({ :template => "books/search" })
+    redirect_to search_path(tab: "books", q: params[:q])
   end
 
   def external_search
-    @external_books = OpenLibraryClient.search_books(params[:q])
-    render({ :template => "books/external_search" })
+    redirect_to search_path(tab: "books", q: params[:q])
   end
 
   def suggest

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,28 @@
 class SearchController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @page_title = 'Search'
+    @active_tab = params[:tab] || 'users'
+
+    if @active_tab == 'books'
+      if params[:q].present?
+        @external_books = OpenLibraryClient.search_books(params[:q])
+      else
+        @external_books = { 'docs' => [] }
+      end
+    else
+      @recent_searches = current_user.search_histories.order(created_at: :desc).limit(5)
+      if params[:q].present?
+        term = "%#{params[:q]}%"
+        @users = User.where('username ILIKE ? OR name ILIKE ?', term, term).where.not(id: current_user.id)
+        current_user.search_histories.create(query: params[:q])
+      else
+        @users = []
+      end
+    end
+  end
+
   def users
     @page_title = 'Search'
     @recent_searches = current_user.search_histories.order(created_at: :desc).limit(5)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,62 @@
+<h1 class="mb-3 text-white">Search</h1>
+
+<ul class="nav nav-tabs mb-3">
+  <li class="nav-item">
+    <%= link_to 'Users', search_path(tab: 'users', q: params[:q]), class: "nav-link #{'active' if @active_tab == 'users'}" %>
+  </li>
+  <li class="nav-item">
+    <%= link_to 'Books', search_path(tab: 'books', q: params[:q]), class: "nav-link #{'active' if @active_tab == 'books'}" %>
+  </li>
+</ul>
+
+<%= form_with url: search_path, method: :get, local: true, class: 'mb-4' do %>
+  <%= hidden_field_tag :tab, @active_tab %>
+  <div class="input-group">
+    <% if @active_tab == 'books' %>
+      <%= text_field_tag :q, params[:q], class: 'form-control', placeholder: 'Search books by title or author', list: 'book-suggestions', data: { controller: 'book-suggest', action: 'input->book-suggest#search', 'book-suggest-target': 'input' } %>
+      <datalist id="book-suggestions" data-book-suggest-target="list"></datalist>
+    <% else %>
+      <%= text_field_tag :q, params[:q], class: 'form-control', placeholder: 'What are you looking for today?' %>
+    <% end %>
+    <button class="btn btn-primary">Search</button>
+  </div>
+<% end %>
+
+<% if @active_tab == 'books' %>
+  <% Array(@external_books['docs']).each do |book| %>
+    <div class="mb-2 p-2 border rounded content-box">
+      <% if book['cover_i'] %>
+        <%= image_tag(OpenLibraryClient.cover_url(book['cover_i'], 'S'), class: 'me-2', size: '50x75') %>
+      <% end %>
+      <strong class="text-white"><%= book['title'] %></strong>
+      <% if book['author_name'] %>
+        <span class="text-muted">by <%= book['author_name'].join(', ') %></span>
+      <% end %>
+      <%= form_with url: '/books/import', method: :post, local: true, class: 'd-inline ms-2' do %>
+        <%= hidden_field_tag :work_id, book['key'].split('/').last %>
+        <button class="btn btn-sm btn-primary">Import</button>
+      <% end %>
+    </div>
+  <% end %>
+  <% if params[:q].present? && Array(@external_books['docs']).empty? %>
+    <p class="text-muted">No books found.</p>
+  <% end %>
+<% else %>
+  <% if @recent_searches.any? %>
+    <h2 class="h5 text-white">Recent searches</h2>
+    <ul class="list-unstyled mb-3">
+      <% @recent_searches.each do |search| %>
+        <li><%= search.query %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% @users.each do |user| %>
+    <div class="mb-2 p-2 border rounded content-box">
+      <%= image_tag(user.avatar.presence || 'default_avatar.png', class: 'avatar me-2') %>
+      <%= link_to user.name, user_path(user), class: 'fw-bold text-decoration-none text-white' %>
+    </div>
+  <% end %>
+  <% if params[:q].present? && @users.empty? %>
+    <p class="text-muted">No users found.</p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root to: "posts#index"
   get "/library", to: "pages#library"
   get "/notifications", to: "pages#notifications"
-  get "/search", to: "search#users", as: :search
+  get "/search", to: "search#index", as: :search
   resources :users, only: [:show] do
     member do
       get :followers

--- a/spec/features/book_suggest_spec.rb
+++ b/spec/features/book_suggest_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Book suggestions", type: :feature, js: true do
       .to_return(status: 200, body: [{ title: "Harry Potter" }].to_json,
                  headers: { "Content-Type" => "application/json" })
 
-    visit "/books/external_search"
+    visit "/search?tab=books"
 
     fill_in "q", with: "Har"
 

--- a/spec/features/external_book_search_spec.rb
+++ b/spec/features/external_book_search_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "External book search", type: :feature do
     stub_request(:get, "https://openlibrary.org/works/OL123W.json")
       .to_return(status: 200, body: work_response.to_json, headers: { "Content-Type" => "application/json" })
 
-    visit "/books/external_search?q=Test+Book"
+    visit "/search?tab=books&q=Test+Book"
 
     expect(page).to have_content("Test Book")
 


### PR DESCRIPTION
## Summary
- add index action for search
- unify /search route to SearchController#index
- redirect book search routes to unified page
- implement tabbed search view for users and books
- update specs for new search paths

## Testing
- `bundle exec rspec spec/features/external_book_search_spec.rb spec/features/book_suggest_spec.rb` *(fails: ruby-3.2.1 is not installed)*