### PR TITLE
Add selectable status for book imports

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -97,7 +97,8 @@ class BooksController < ApplicationController
   end
 
   def import
-    work_id = params[:work_id]
+    permitted = params.permit(:work_id, :status)
+    work_id = permitted[:work_id]
     work    = OpenLibraryClient.fetch_work(work_id)
 
     author_name = work.dig("authors", 0, "name") ||
@@ -118,7 +119,7 @@ class BooksController < ApplicationController
     book.save!
 
     current_user.readings.find_or_create_by(book: book) do |r|
-      r.status = "want_to_read"
+      r.status = permitted[:status] || "want_to_read"
     end
 
     redirect_to "/library", notice: "Book imported successfully."

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -1,7 +1,8 @@
 class ReadingsController < ApplicationController
   def create
-    reading = current_user.readings.find_or_initialize_by(book_id: params[:book_id])
-    reading.status = params[:status] || 'want_to_read'
+    permitted = params.permit(:book_id, :status)
+    reading = current_user.readings.find_or_initialize_by(book_id: permitted[:book_id])
+    reading.status = permitted[:status] || 'want_to_read'
     reading.save
     redirect_to '/library', notice: 'Book added to your library.'
   end

--- a/app/views/books/external_search.html.erb
+++ b/app/views/books/external_search.html.erb
@@ -19,6 +19,9 @@
     <% end %>
     <%= form_with url: '/books/import', method: :post, local: true, class: 'd-inline ms-2' do %>
       <%= hidden_field_tag :work_id, book['key'].split('/').last %>
+      <%= select_tag :status,
+        options_for_select(Reading::STATUSES.map { |s| [s.humanize, s] }, 'want_to_read'),
+        class: 'form-select form-select-sm d-inline w-auto me-2' %>
       <button class="btn btn-sm btn-primary">Import</button>
     <% end %>
   </div>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -14,7 +14,9 @@
     <span class="text-muted">by <%= book.author.name if book.author %></span>
     <%= form_with url: insert_reading_path, method: :post, local: true, class: 'd-inline ms-2' do %>
       <%= hidden_field_tag :book_id, book.id %>
-      <%= hidden_field_tag :status, 'want_to_read' %>
+      <%= select_tag :status,
+        options_for_select(Reading::STATUSES.map { |s| [s.humanize, s] }, 'want_to_read'),
+        class: 'form-select form-select-sm d-inline w-auto me-2' %>
       <button class="btn btn-sm btn-primary">Add to Library</button>
     <% end %>
   </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -34,6 +34,9 @@
       <% end %>
       <%= form_with url: '/books/import', method: :post, local: true, class: 'd-inline ms-2' do %>
         <%= hidden_field_tag :work_id, book['key'].split('/').last %>
+        <%= select_tag :status,
+          options_for_select(Reading::STATUSES.map { |s| [s.humanize, s] }, 'want_to_read'),
+          class: 'form-select form-select-sm d-inline w-auto me-2' %>
         <button class="btn btn-sm btn-primary">Import</button>
       <% end %>
     </div>

--- a/spec/features/external_book_search_spec.rb
+++ b/spec/features/external_book_search_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "External book search", type: :feature do
     expect(page).to have_content("Test Book")
 
     expect do
+      select "reading", from: "status", match: :first
       click_button "Import", match: :first
     end.to change(Book, :count).by(1).and change(Reading, :count).by(1)
 

--- a/spec/features/unified_search_spec.rb
+++ b/spec/features/unified_search_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Unified search", type: :feature do
     expect(page).to have_content("Test Book")
 
     expect do
+      select "reading", from: "status", match: :first
       click_button "Import", match: :first
     end.to change(Book, :count).by(1).and change(Reading, :count).by(1)
 


### PR DESCRIPTION
## Summary
- allow choosing book status when adding/importing
- pass selected status through readings and book import controllers
- update external book search and unified search specs

## Testing
- `bundle exec rspec spec/features/unified_search_spec.rb -fp` *(fails: bundler: command not found)*