### PR TITLE
Add unique reading constraint and specs

### DIFF
--- a/app/models/reading.rb
+++ b/app/models/reading.rb
@@ -19,4 +19,5 @@ class Reading < ApplicationRecord
   STATUSES = %w[want_to_read reading finished]
   validates :status, inclusion: { in: STATUSES }
   validates :progress, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :book_id, uniqueness: { scope: :user_id }
 end

--- a/db/migrate/20250717000000_add_unique_index_to_readings.rb
+++ b/db/migrate/20250717000000_add_unique_index_to_readings.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToReadings < ActiveRecord::Migration[7.1]
+  def change
+    add_index :readings, [:user_id, :book_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_16_000001) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_16_000001) do
     t.datetime "updated_at", null: false
     t.integer "progress"
     t.text "review"
+    t.index ["user_id", "book_id"], name: "index_readings_on_user_id_and_book_id", unique: true
   end
 
   create_table "search_histories", force: :cascade do |t|

--- a/spec/factories/readings.rb
+++ b/spec/factories/readings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :reading do
+    association :user
+    association :book
+    status { "want_to_read" }
+  end
+end

--- a/spec/models/reading_spec.rb
+++ b/spec/models/reading_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Reading, type: :model do
+  subject { build(:reading) }
+
+  it { is_expected.to validate_uniqueness_of(:book_id).scoped_to(:user_id) }
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+require 'shoulda/matchers'
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
## Summary
- enforce one reading per user per book
- add unique index migration
- update schema with index
- configure Shoulda Matchers
- add reading factory and model spec

## Testing
- `bundle exec rspec` *(fails: rbenv: version `ruby-3.2.1` is not installed)*