### PR TITLE
Add fetch_edition to OpenLibraryClient

### DIFF
--- a/lib/open_library_client.rb
+++ b/lib/open_library_client.rb
@@ -1,6 +1,7 @@
 class OpenLibraryClient
   BASE_SEARCH_URL = 'https://openlibrary.org/search.json'
   BASE_WORKS_URL  = 'https://openlibrary.org/works'
+  BASE_BOOKS_URL  = 'https://openlibrary.org/books'
   BASE_COVER_URL  = 'https://covers.openlibrary.org/b/id'
 
   def self.search_books(query)
@@ -10,6 +11,11 @@ class OpenLibraryClient
 
   def self.fetch_work(work_id)
     response = HTTP.get("#{BASE_WORKS_URL}/#{work_id}.json")
+    JSON.parse(response.to_s)
+  end
+
+  def self.fetch_edition(edition_id)
+    response = HTTP.get("#{BASE_BOOKS_URL}/#{edition_id}.json")
     JSON.parse(response.to_s)
   end
 

--- a/spec/lib/open_library_client_spec.rb
+++ b/spec/lib/open_library_client_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe OpenLibraryClient do
+  describe '.fetch_edition' do
+    it 'returns parsed JSON for the requested edition' do
+      edition_id = 'OL123M'
+      body = { 'title' => 'Edition Title' }.to_json
+
+      stub_request(:get, "https://openlibrary.org/books/#{edition_id}.json")
+        .to_return(status: 200, body: body, headers: { 'Content-Type' => 'application/json' })
+
+      result = described_class.fetch_edition(edition_id)
+      expect(result['title']).to eq('Edition Title')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow fetching of Open Library editions
- test the new fetch_edition method

## Testing
- `bundle exec rspec spec/lib/open_library_client_spec.rb` *(fails: rbenv: version `ruby-3.2.1` is not installed)*