### PR TITLE
Add book details route and action

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -124,4 +124,18 @@ class BooksController < ApplicationController
 
     redirect_to "/library", notice: "Book imported successfully."
   end
+
+  def details
+    @work = OpenLibraryClient.fetch_work(params[:work_id])
+    @edition = OpenLibraryClient.fetch_edition(params[:edition_id]) if params[:edition_id].present?
+
+    author_name = @work.dig('authors', 0, 'name') ||
+                  @work.dig('authors', 0, 'author', 'name')
+    author = Author.find_by(name: author_name)
+
+    @local_book = Book.find_by(title: @work['title'], author: author)
+    @read_count        = @local_book&.readings.where(status: 'finished')&.count || 0
+    @reading_count     = @local_book&.readings.where(status: 'reading')&.count  || 0
+    @want_to_read_count = @local_book&.readings.where(status: 'want_to_read')&.count || 0
+  end
 end

--- a/app/views/books/details.html.erb
+++ b/app/views/books/details.html.erb
@@ -1,0 +1,11 @@
+<h1 class="mb-3 text-white"><%= @work['title'] %></h1>
+
+<% if @edition %>
+  <p class="text-white">Edition: <%= @edition['title'] %></p>
+<% end %>
+
+<ul class="list-unstyled text-muted">
+  <li>Finished: <%= @read_count %></li>
+  <li>Reading: <%= @reading_count %></li>
+  <li>Want to read: <%= @want_to_read_count %></li>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
   get '/books/external_search' => 'books#external_search'
   get '/books/suggest' => 'books#suggest'
   post '/books/import' => 'books#import'
+  get '/books/details/:work_id' => 'books#details', as: :book_details
 
   get("/books/:path_id", { :controller => "books", :action => "show" })
 

--- a/lib/open_library_client.rb
+++ b/lib/open_library_client.rb
@@ -1,6 +1,7 @@
 class OpenLibraryClient
   BASE_SEARCH_URL = 'https://openlibrary.org/search.json'
   BASE_WORKS_URL  = 'https://openlibrary.org/works'
+  BASE_BOOKS_URL  = 'https://openlibrary.org/books'
   BASE_COVER_URL  = 'https://covers.openlibrary.org/b/id'
 
   def self.search_books(query)
@@ -10,6 +11,11 @@ class OpenLibraryClient
 
   def self.fetch_work(work_id)
     response = HTTP.get("#{BASE_WORKS_URL}/#{work_id}.json")
+    JSON.parse(response.to_s)
+  end
+
+  def self.fetch_edition(edition_id)
+    response = HTTP.get("#{BASE_BOOKS_URL}/#{edition_id}.json")
     JSON.parse(response.to_s)
   end
 

--- a/spec/features/book_details_spec.rb
+++ b/spec/features/book_details_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Book details', type: :feature do
+  let(:user) { create(:user) }
+  let(:author) { create(:author, name: 'Jane Doe') }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  it 'shows work info and reading counts' do
+    book = create(:book, title: 'Test Work', author: author)
+    create_list(:reading, 2, book: book, status: 'finished')
+    create_list(:reading, 1, book: book, status: 'reading')
+    create_list(:reading, 3, book: book, status: 'want_to_read')
+
+    work_response = {
+      'title' => 'Test Work',
+      'authors' => [{ 'name' => 'Jane Doe' }]
+    }
+
+    stub_request(:get, 'https://openlibrary.org/works/OL123W.json')
+      .to_return(status: 200, body: work_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    visit '/books/details/OL123W'
+
+    expect(page).to have_content('Test Work')
+    expect(page).to have_content('Finished: 2')
+    expect(page).to have_content('Reading: 1')
+    expect(page).to have_content('Want to read: 3')
+  end
+
+  it 'fetches edition data when edition_id provided' do
+    work_response = {
+      'title' => 'Another Book',
+      'authors' => [{ 'name' => 'Jane Doe' }]
+    }
+    edition_response = { 'title' => 'Another Book - First Edition' }
+
+    stub_request(:get, 'https://openlibrary.org/works/OL456W.json')
+      .to_return(status: 200, body: work_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://openlibrary.org/books/OL1M.json')
+      .to_return(status: 200, body: edition_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    visit '/books/details/OL456W?edition_id=OL1M'
+
+    expect(page).to have_content('Another Book')
+    expect(page).to have_content('Edition: Another Book - First Edition')
+  end
+end


### PR DESCRIPTION
## Summary
- add OpenLibrary edition fetch helper
- expose details route for books
- compute reading status counts in controller
- render simple book details page
- test book details behavior

## Testing
- `bundle exec rspec spec/features/book_details_spec.rb --format doc -fd` *(fails: rbenv: version `ruby-3.2.1` is not installed)*