### PR TITLE
Fix explore feed filtering

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,10 +52,16 @@ class User < ApplicationRecord
 
   has_many :feed, through: :following, source: :posts
 
-  # Posts from people your followings follow
+  # Posts from people followed by your followings
+  # Excludes posts from yourself and people you already follow
   has_many :extended_following, through: :following, source: :following
   has_many :explore_feed,
-           -> { joins(:creator).where(users: { is_private: false }) },
+           ->(user) {
+             joins(:creator)
+               .where(users: { is_private: false })
+               .where.not(creator_id: user.following.ids + [user.id])
+               .distinct
+           },
            through: :extended_following,
            source: :posts
 

--- a/spec/factories/followrequests.rb
+++ b/spec/factories/followrequests.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :followrequest do
+    association :sender, factory: :user
+    association :recipient, factory: :user
+    status { 'accepted' }
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    association :creator, factory: :user
+    content { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/user_explore_feed_spec.rb
+++ b/spec/models/user_explore_feed_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '#explore_feed' do
+    it 'excludes self and followed users' do
+      user = create(:user)
+      followed = create(:user)
+      stranger = create(:user)
+
+      create(:followrequest, sender: user, recipient: followed, status: 'accepted')
+      create(:followrequest, sender: followed, recipient: stranger, status: 'accepted')
+
+      my_post = create(:post, creator: user)
+      followed_post = create(:post, creator: followed)
+      stranger_post = create(:post, creator: stranger)
+
+      expect(user.explore_feed).to include(stranger_post)
+      expect(user.explore_feed).not_to include(my_post)
+      expect(user.explore_feed).not_to include(followed_post)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- update explore_feed association to exclude self and existing followings
- add factories for posts and follow requests
- test explore_feed behavior

## Testing
- `bundle exec rspec` *(fails: rbenv: version `ruby-3.2.1` is not installed)*