### PR TITLE
Add feature spec for book details import

### DIFF
--- a/app/views/books/external_search.html.erb
+++ b/app/views/books/external_search.html.erb
@@ -17,6 +17,7 @@
     <% if book['author_name'] %>
       <span class="text-muted">by <%= book['author_name'].join(', ') %></span>
     <% end %>
+    <%= link_to 'Details', book_details_path(work_id: book['key'].split('/').last, edition_id: book['edition_key']&.first), class: 'btn btn-link btn-sm text-decoration-none' %>
     <%= form_with url: '/books/import', method: :post, local: true, class: 'd-inline ms-2' do %>
       <%= hidden_field_tag :work_id, book['key'].split('/').last %>
       <%= select_tag :status,

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -32,6 +32,7 @@
       <% if book['author_name'] %>
         <span class="text-muted">by <%= book['author_name'].join(', ') %></span>
       <% end %>
+      <%= link_to 'Details', book_details_path(work_id: book['key'].split('/').last, edition_id: book['edition_key']&.first), class: 'btn btn-link btn-sm text-decoration-none' %>
       <%= form_with url: '/books/import', method: :post, local: true, class: 'd-inline ms-2' do %>
         <%= hidden_field_tag :work_id, book['key'].split('/').last %>
         <%= select_tag :status,

--- a/spec/features/book_details_spec.rb
+++ b/spec/features/book_details_spec.rb
@@ -50,4 +50,57 @@ RSpec.describe 'Book details', type: :feature do
     expect(page).to have_content('Another Book')
     expect(page).to have_content('Edition: Another Book - First Edition')
   end
+
+  it 'shows details from search results and allows importing' do
+    search_response = {
+      'docs' => [
+        {
+          'title' => 'Search Book',
+          'author_name' => ['Jane Doe'],
+          'key' => '/works/OL789W',
+          'edition_key' => ['OL2M']
+        }
+      ]
+    }
+
+    stub_request(:get, 'https://openlibrary.org/search.json')
+      .with(query: hash_including(q: 'Search Book'))
+      .to_return(status: 200, body: search_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    work_response = {
+      'title' => 'Search Book',
+      'authors' => [{ 'name' => 'Jane Doe' }],
+      'number_of_pages' => 321
+    }
+
+    edition_response = {
+      'title' => 'Search Book - Second Edition',
+      'number_of_pages' => 321
+    }
+
+    stub_request(:get, 'https://openlibrary.org/works/OL789W.json')
+      .to_return(status: 200, body: work_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://openlibrary.org/books/OL2M.json')
+      .to_return(status: 200, body: edition_response.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    visit '/search?tab=books&q=Search+Book'
+    click_link 'Details', match: :first
+
+    expect(page).to have_content('Jane Doe')
+    expect(page).to have_content('Page length: 321')
+    expect(page).to have_content('Edition: Search Book - Second Edition')
+    expect(page).to have_content('Finished: 0')
+    expect(page).to have_content('Reading: 0')
+    expect(page).to have_content('Want to read: 0')
+
+    expect do
+      click_button 'Add to Library'
+    end.to change(Book, :count).by(1).and change(Reading, :count).by(1)
+
+    visit '/books/details/OL789W?edition_id=OL2M'
+    expect(page).to have_content('Want to read: 1')
+  end
 end


### PR DESCRIPTION
## Summary
- add feature spec verifying book detail page from search
- show `Details` links on book search results

## Testing
- `bundle exec rspec spec/features/book_details_spec.rb --format doc -o /tmp/rspec.txt && tail -n 20 /tmp/rspec.txt` *(fails: ruby-3.2.1 is not installed)*