### PR TITLE
Fix sample_data cleanup order

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,7 +1,7 @@
 desc "Fill the database tables with some sample data"
 task sample_data: :environment do
   puts "Cleaning existing records..."
-  [ActiveStorage::Attachment, ActiveStorage::Blob, Notification, Like, Comment, Post, Reading, Book, Author, Followrequest, User].each(&:delete_all)
+  [ActiveStorage::Attachment, ActiveStorage::Blob, Notification, Like, Comment, Post, Reading, SearchHistory, Book, Author, Followrequest, User].each(&:delete_all)
 
   puts "Creating main user..."
   main_user = User.create!(


### PR DESCRIPTION
## Summary
- include `SearchHistory` in the cleanup phase of `sample_data`

Fixes rake task failure caused by foreign key references when wiping existing records.

## Testing
- `bundle exec rake spec` *(fails: rbenv ruby-3.2.1 not installed)*