### PR TITLE
Fix posts counter cache error

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,7 @@
 class Post < ApplicationRecord
   #Direct Associations
   belongs_to :creator, required: true, class_name: "User", foreign_key: "creator_id", counter_cache: true
-  belongs_to :book, class_name: "Book", foreign_key: "book_id", optional: true, counter_cache: true
+  belongs_to :book, class_name: "Book", foreign_key: "book_id", optional: true
   has_many  :likes, class_name: "Like", foreign_key: "post_id", dependent: :destroy
   has_many  :comments, class_name: "Comment", foreign_key: "post_id", dependent: :destroy
   has_many_attached :media


### PR DESCRIPTION
## Summary
- remove `counter_cache` from the Post to Book association

## Testing
- `bundle exec rails test` *(fails: rbenv: version `ruby-3.2.1` is not installed)*