### PR TITLE
Implement automatic reading posts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,14 @@ class User < ApplicationRecord
 
   scope :publicly_visible, -> { where(is_private: false) }
 
+  def random_currently_reading_book
+    reading_books
+      .joins(:readings)
+      .where(readings: { status: 'reading' })
+      .order(Arel.sql('RANDOM()'))
+      .first
+  end
+
   def timeline
     Post.where(creator_id: following.ids + [id])
   end

--- a/app/views/posts/_post_card.html.erb
+++ b/app/views/posts/_post_card.html.erb
@@ -6,6 +6,9 @@
       <div class="d-flex align-items-center">
         <strong class="text-white"><%= link_to post.creator.name, user_path(post.creator), class: 'text-white' %></strong>
         <span class="ms-2 text-white">@<%= link_to post.creator.username, user_path(post.creator), class: 'text-white' %></span>
+        <% if (current_book = post.creator.random_currently_reading_book) %>
+          <small class="ms-2 text-muted">reading <%= link_to current_book.title, book_path(current_book) %></small>
+        <% end %>
       </div>
       <p class="mb-1"><%= post.content %></p>
       <% if post.book %>

--- a/spec/models/reading_spec.rb
+++ b/spec/models/reading_spec.rb
@@ -23,4 +23,21 @@ RSpec.describe Reading, type: :model do
   subject { build(:reading) }
 
   it { is_expected.to validate_uniqueness_of(:book_id).scoped_to(:user_id) }
+
+  describe 'status change' do
+    let(:user) { create(:user) }
+    let(:book) { create(:book) }
+
+    it 'creates a post when starting to read' do
+      reading = Reading.create(user: user, book: book, status: 'reading')
+      expect(Post.last.book).to eq(book)
+    end
+
+    it 'creates a post when moving from want_to_read to reading' do
+      reading = Reading.create(user: user, book: book, status: 'want_to_read')
+      expect do
+        reading.update(status: 'reading')
+      end.to change(Post, :count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- surface what a user is reading next to their name on posts
- make post when a reading status changes to `reading`
- test the callback behaviour

## Testing
- `bundle exec rake spec` *(fails: ruby-3.2.1 not installed)*