### PR TITLE
Add AI librarian chat tab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPEN_AI_KEY=your-openai-key

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ examples.txt
 
 # Ignore dotenv files
 /.env*
+!/.env.example
 
 # Un-ignore SQLite3 db
 !/db/*.sqlite3

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,12 +3,34 @@ class PagesController < ApplicationController
     @page_title = "Library"
     @user = current_user
     @active_tab = params[:tab] || 'public'
-    scope = @user.readings.includes(:book)
-    scope = scope.where(is_private: true) if @active_tab == 'private'
-    scope = scope.where(is_private: false) if @active_tab == 'public'
-    @reading_now  = scope.where(status: 'reading')
-    @want_to_read = scope.where(status: 'want_to_read')
-    @finished     = scope.where(status: 'finished')
+
+    unless @active_tab == 'ai'
+      scope = @user.readings.includes(:book)
+      scope = scope.where(is_private: true) if @active_tab == 'private'
+      scope = scope.where(is_private: false) if @active_tab == 'public'
+      @reading_now  = scope.where(status: 'reading')
+      @want_to_read = scope.where(status: 'want_to_read')
+      @finished     = scope.where(status: 'finished')
+    end
+
+    @chat_history = session[:ai_history] || []
+  end
+
+  def ai_chat
+    session[:ai_history] ||= [
+      {
+        role: 'system',
+        content: 'You are an all-knowing librarian who knows every book ever created. You recommend books based on the reader\'s mood, reading level, experience, desired length, and any other preferences. Explain suggestions using simple words a beginning reader can understand.'
+      }
+    ]
+
+    if params[:message].present?
+      session[:ai_history] << { role: 'user', content: params[:message] }
+      response = OpenAiService.new.chat(session[:ai_history])
+      session[:ai_history] << { role: 'assistant', content: response }
+    end
+
+    redirect_to library_path(tab: 'ai')
   end
 
   def notifications

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -1,0 +1,16 @@
+class OpenAiService
+  CHAT_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+  MODEL = "gpt-3.5-turbo"
+
+  def initialize(api_key: ENV["OPEN_AI_KEY"])
+    @api_key = api_key
+  end
+
+  def chat(messages)
+    response = HTTP.headers(
+      "Authorization" => "Bearer #{@api_key}",
+      "Content-Type" => "application/json"
+    ).post(CHAT_ENDPOINT, json: { model: MODEL, messages: messages })
+    JSON.parse(response.body.to_s).dig("choices", 0, "message", "content")
+  end
+end

--- a/app/views/pages/_library_ai_chat.html.erb
+++ b/app/views/pages/_library_ai_chat.html.erb
@@ -1,0 +1,17 @@
+<h2 class="h5 mb-3">Ask the Librarian</h2>
+<%= form_with url: library_ai_chat_path, method: :post, local: true do %>
+  <div class="mb-2">
+    <%= text_area_tag :message, nil, class: 'form-control', placeholder: 'Describe your mood or what you want to read...' %>
+  </div>
+  <%= submit_tag 'Get Suggestions', class: 'btn btn-primary' %>
+<% end %>
+
+<div class="mt-4">
+  <% @chat_history.each do |msg| %>
+    <% next if msg[:role] == 'system' %>
+    <div class="mb-2">
+      <strong><%= msg[:role] == 'user' ? 'You' : 'Librarian' %>:</strong>
+      <%= simple_format(msg[:content]) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pages/library.html.erb
+++ b/app/views/pages/library.html.erb
@@ -6,8 +6,15 @@
     <li class="nav-item">
       <%= link_to 'Private', library_path(tab: 'private'), class: "nav-link #{@active_tab == 'private' ? 'active' : ''}" %>
     </li>
+    <li class="nav-item">
+      <%= link_to 'Ask Librarian', library_path(tab: 'ai'), class: "nav-link #{@active_tab == 'ai' ? 'active' : ''}" %>
+    </li>
   </ul>
 <% end %>
+
+<% if @active_tab == 'ai' %>
+  <%= render 'library_ai_chat' %>
+<% else %>
 
 <h2 class="h5 mb-3">Currently Reading</h2>
 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-5 g-3 mb-4">
@@ -125,3 +132,4 @@
     </div>
   <% end %>
 </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module RailsTemplate
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.eager_load_paths << Rails.root.join("app/services")
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   }
   root to: "posts#index"
   get "/library", to: "pages#library"
+  post "/library/ai_chat", to: "pages#ai_chat", as: :library_ai_chat
   get "/notifications", to: "pages#notifications"
   get "/search", to: "search#index", as: :search
   resources :users, only: [:show] do


### PR DESCRIPTION
## Summary
- set up `.env.example` with `OPEN_AI_KEY`
- allow `.env.example` to be committed
- add `OpenAiService` for talking to OpenAI
- add Ask Librarian tab with chat interface
- route POST requests to `PagesController#ai_chat`
- load service via Rails eager_load_paths

## Testing
- `bundle exec rspec` *(fails: rbenv: version `ruby-3.2.1` is not installed)*