### PR TITLE
Fix AI service loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module RailsTemplate
     config.load_defaults 7.0
 
     config.eager_load_paths << Rails.root.join("app/services")
+    config.autoload_paths << Rails.root.join("app/services")
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
## Summary
- autoload service objects from `app/services`

## Testing
- `rails test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*