### PR TITLE
Integrate OpenAI gem for librarian chat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem "sqlite3", "~> 1.4"
 gem "table_print"
 gem "simple_form"
 gem "carrierwave"
-gem "openai-chat"
+gem "openai"
 
 group :development do
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,8 +269,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     oj (3.13.23)
-    openai-chat (0.0.3)
-      mime-types (~> 3.0)
+    openai (4.0.0)
     orm_adapter (0.5.0)
     pg (1.5.6)
     pry (0.14.2)
@@ -494,7 +493,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kredis
-  openai-chat
+  openai
   pg (~> 1.1)
   pry-rails
   puma

--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ rails db:create db:migrate
 rake sample_data
 ```
 
+Ensure that an `OPENAI_API_KEY` environment variable is set with your OpenAI API key for librarian chat features.
+

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -1,16 +1,19 @@
+require "openai"
+
 class OpenAiService
-  CHAT_ENDPOINT = "https://api.openai.com/v1/chat/completions"
   MODEL = "gpt-3.5-turbo"
 
-  def initialize(api_key: ENV["OPEN_AI_KEY"])
-    @api_key = api_key
+  def initialize(client: OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY")))
+    @client = client
   end
 
   def chat(messages)
-    response = HTTP.headers(
-      "Authorization" => "Bearer #{@api_key}",
-      "Content-Type" => "application/json"
-    ).post(CHAT_ENDPOINT, json: { model: MODEL, messages: messages })
-    JSON.parse(response.body.to_s).dig("choices", 0, "message", "content")
+    api_response = @client.chat(
+      parameters: {
+        model: MODEL,
+        messages: messages
+      }
+    )
+    api_response.dig("choices", 0, "message", "content")
   end
 end


### PR DESCRIPTION
## Summary
- replace custom HTTP calls with `openai` gem in `OpenAiService`
- depend on the `openai` gem
- note required `OPENAI_API_KEY` variable in README

## Testing
- `bin/rails test` *(fails: ruby-3.2.1 is not installed)*
- `bundle exec rspec` *(fails: ruby-3.2.1 is not installed)*