### PR TITLE
Improve API key check for librarian chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ rake sample_data
 
 Ensure that an `OPENAI_API_KEY` environment variable is set with your OpenAI API key for librarian chat features.
 
+If you see an error like `Errno::ENOENT @ rb_sysopen - 0.0.0.0` when submitting a question to the librarian chat, double check that `OPENAI_API_KEY` is pointing to your actual API key value and not a placeholder such as `0.0.0.0`.
+

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -3,7 +3,11 @@ require "openai"
 class OpenAiService
   MODEL = "gpt-3.5-turbo"
 
-  def initialize(client: OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY")))
+  def initialize(client: nil)
+    api_key = ENV["OPENAI_API_KEY"]
+    raise "OPENAI_API_KEY environment variable is missing" if api_key.nil? || api_key.strip.empty?
+
+    client ||= OpenAI::Client.new(access_token: api_key)
     @client = client
   end
 


### PR DESCRIPTION
## Summary
- validate the presence of `OPENAI_API_KEY` before creating the OpenAI client
- clarify README with troubleshooting note for missing or placeholder API key

## Testing
- `bundle exec rake spec` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.2.1)*