### PR TITLE
Fix AI librarian chat display

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,26 +13,26 @@ class PagesController < ApplicationController
       @finished = scope.where(status: "finished")
     end
 
-    @chat_history = session[:ai_history] || []
+    @chat_history = (session[:ai_history] || []).map(&:symbolize_keys)
   end
 
   def ai_chat
     session[:ai_history] ||= [
       {
-        role: "system",
-        content: "You are an all-knowing librarian who knows every book ever created. You recommend books based on the reader's mood, reading level, experience, desired length, and any other preferences. Explain suggestions using simple words a beginning reader can understand."
+        "role" => "system",
+        "content" => "You are an all-knowing librarian who knows every book ever created. You recommend books based on the reader's mood, reading level, experience, desired length, and any other preferences. Explain suggestions using simple words a beginning reader can understand."
       },
     ]
 
     user_message = params[:message].to_s.strip
 
     if user_message.present?
-      session[:ai_history] << { role: "user", content: user_message }
+      session[:ai_history] << { "role" => "user", "content" => user_message }
 
       service = OpenAiService.new
       assistant_response = service.chat(session[:ai_history])
 
-      session[:ai_history] << { role: "assistant", content: assistant_response }
+      session[:ai_history] << { "role" => "assistant", "content" => assistant_response }
     end
 
     redirect_to library_path(tab: "ai")

--- a/app/views/pages/_library_ai_chat.html.erb
+++ b/app/views/pages/_library_ai_chat.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-2">
     <%= text_area_tag :message, nil, class: 'form-control', placeholder: 'Describe your mood or what you want to read...' %>
   </div>
-  <%= submit_tag 'Get Suggestions', class: 'btn btn-primary' %>
+  <%= submit_tag 'Ask Librarian', class: 'btn btn-primary' %>
 <% end %>
 
 <div class="mt-4">


### PR DESCRIPTION
## Summary
- symbolize session keys so chat history renders correctly
- store chat history messages with string keys
- update AI chat button text to "Ask Librarian"

## Testing
- `bundle exec rspec` *(fails: ruby 3.2.1 not installed)*